### PR TITLE
updating of driver for ros melodic support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,28 @@
 
 # About
 This is a ROS metapackage for both Sensable Phantom Omni (IEEE1394 connection) 
-and Geomagic Touch (Ethernet connection). Included in this metapackage is the
-omni_driver package, which contains the omni_driver node. If you don't know or don't have ROS, you
-should first go to http://www.ros.org/.
+and Geomagic Touch (Ethernet/USB connection). As of this moment it has not been tested with the parallel port version of the Sensable Phantom Omni. Work is welcome to help support this feature. Included in this metapackage is the omni_driver package, which contains the omni_driver node. If you don't know or don't have ROS, you should first go to http://www.ros.org/. This repository is based off a number of other repositories. Many of the above repositories are evolutions of each other or are good descriptors of interacting with the various versions of the Pahntom Omni/Geomagic Touch. 
+
+The heritage of the current driver is:
+
+```
+Dane Powell's Driver -> 
+Francisco Suárez-Ruiz Driver -> 
+Grupo de Sistemas de Controle em Automação e Robótica Driver -> 
+This repository
+```
+ Thanks go to:
+- [https://gitlab.com/gscar-coppe-ufrj/ros/PhantomOmni](https://gitlab.com/gscar-coppe-ufrj/ros/PhantomOmni)
+- [https://github.com/JimAdara/Touch_ROS_Driver](https://github.com/JimAdara/Touch_ROS_Driver)
+- [https://github.com/sunghowoo/Control-of-two-UR5s-by-two-phantom-omnies-](https://github.com/sunghowoo/Control-of-two-UR5s-by-two-phantom-omnies-)
+- [https://github.com/bharatm11/Geomagic_Touch_ROS_Drivers](https://github.com/bharatm11/Geomagic_Touch_ROS_Drivers)
+- [https://github.com/fsuarez6/phantom_omni](https://github.com/fsuarez6/phantom_omni)
+- [https://github.com/HumaRobotics/geomagic_touch](https://github.com/HumaRobotics/geomagic_touch)
+- [https://github.com/iyerkritika/modular_teleop](https://github.com/iyerkritika/modular_teleop)
+- [https://github.com/stephanniec/baxter_telehaptics](https://github.com/stephanniec/baxter_telehaptics)
+- [https://github.com/ytsutano/raw_omni](https://github.com/ytsutano/raw_omni)
+- [https://github.com/danepowell/phantom_omni](https://github.com/danepowell/phantom_omni)
+- [https://github.com/danepowell/omni_description](https://github.com/danepowell/omni_description)
 
 # Usage
 
@@ -49,7 +68,7 @@ If you want to use a FireWire device, run:
 ```sh 
 $ roslaunch omni_driver firewire.launch
 ```
-Additionally, you need to update the serial number on the omni.launch file so that it matches yours. The Ethernet version doesn't need this step.
+Additionally, you need to update the serial number on the omni.launch file so that it matches yours. The Ethernet/USB version doesn't need this step.
 Go to omni_driver/launch/omni.launch and look for this line:
 ```sh
 $ <param name="omni_type" type="string" value="$(arg type)" />
@@ -57,7 +76,7 @@ $ <param name="omni_type" type="string" value="$(arg type)" />
 ```
 Then change the value to match your device's serial number.
 
-If Ethernet is the one you're using, then:
+If Ethernet/USB is the one you're using, then:
 ```sh 
 $ roslaunch omni_driver ethernet.launch
 ```
@@ -69,6 +88,8 @@ $ roslaunch omni_driver ethernet_slave.launch
 ```
 
 # Dependencies
+> This is a work in progress. The docker image descrbed below does not contain the latest code from this repository. I am working on adding a Github Action to generate builds for multiple ROS versions and Ubuntu versions. This will take a little time. The first version that will be supported is ROS Melodic on Ubuntu 18.04 as this is the current version I am working on. Please be patient or feel free to create a PR for review. Different versions of the drivers and ROS will require loading of different libraries.
+
 The list of dependencies is quite large, so we decided to provide a Docker image with
 everything ready to run. Therefore, using this Software through Docker is recommended because very little
 setting up is needed to get the program up and running. If Docker is your way to go, skip 

--- a/omni_controller/CMakeLists.txt
+++ b/omni_controller/CMakeLists.txt
@@ -16,11 +16,14 @@ endif ()
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED
+    roscpp
     geometry_msgs
     std_msgs
     joy)
 
 find_package(Eigen3 REQUIRED)
+
+set(EIGEN3_INCLUDE_DIR /usr/include/eigen3)
 
 ###################################
 ## catkin specific configuration ##
@@ -80,5 +83,5 @@ target_link_libraries(omni_controller ${catkin_LIBRARIES} robot_kinematics)
 
 ## Create test program
 add_executable(robot_test ${PROJECT_SOURCE_DIR}/src/test/main.cpp ${PROJECT_SOURCE_DIR}/src/node/Omni.cpp)
-target_link_libraries(robot_test robot_kinematics)
+target_link_libraries(robot_test robot_kinematics  ${catkin_LIBRARIES})
 

--- a/omni_driver/CMakeLists.txt
+++ b/omni_driver/CMakeLists.txt
@@ -101,7 +101,7 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
   ${Boost_INCLUDE_DIRS}
   include
-  "${EIGEN3_INCLUDE_DIR}"
+  ${EIGEN3_INCLUDE_DIR}
 )
 
 ## Declare a cpp library

--- a/omni_driver/include/omnibase.h
+++ b/omni_driver/include/omnibase.h
@@ -13,7 +13,7 @@
 #include <std_msgs/Float64MultiArray.h>
 #include <moveit/planning_interface/planning_interface.h>
 #include <moveit/planning_scene_interface/planning_scene_interface.h>
-#include <moveit/move_group_interface/move_group.h>
+// #include <moveit/move_group_interface/move_group.h>
 #include <moveit_msgs/DisplayTrajectory.h>
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/robot_model/robot_model.h>

--- a/omni_driver/include/omnifirewire.h
+++ b/omni_driver/include/omnifirewire.h
@@ -1,6 +1,5 @@
 #pragma once
 
-
 #include "omnibase.h"
 #include "ros/ros.h"
 #include "raw1394msg.h"

--- a/omni_driver/src/omnibase.cpp
+++ b/omni_driver/src/omnibase.cpp
@@ -5,8 +5,8 @@
 #include <iostream>
 
 
-typedef boost::shared_ptr<urdf::Model> URDFModelPtr;
-typedef boost::shared_ptr<srdf::Model> SRDFModelPtr;
+typedef std::shared_ptr<urdf::Model> URDFModelPtr;
+typedef std::shared_ptr<srdf::Model> SRDFModelPtr;
 
 OmniBase::OmniBase(const std::string &name, const std::string &path_urdf, const std::string &path_srdf)
     : OmniBase::OmniBase(name, path_urdf , path_srdf , 1000)

--- a/omni_driver/src/omniethernet.cpp
+++ b/omni_driver/src/omniethernet.cpp
@@ -2,6 +2,13 @@
 
 int OmniEthernet::calibrationStyle = 0;
 
+/**
+ * TODO: This class can be renamed to be a generic driver for the Geomagic Touch 
+ * devices. Eithernet and USB share a single driver and a unified interface in 
+ * OpenHaptics. Once the device is configured in the Touch_Setup it is then 
+ * referenced by name from then on. Further work will be undertaken to improve 
+ * the ability to used names other than the default.
+ **/
 OmniEthernet::OmniEthernet(const std::string &name, const std::string &path_urdf, const std::string &path_srdf) :
     OmniBase(name, path_urdf, path_srdf)
 {
@@ -24,7 +31,7 @@ void OmniEthernet::getJointAnglesFromDriver()
     double gimbal2deg2rad = 0.0735 * M_PI / 180;
 
     // Getting time difference between two consecutive reading.
-//    state.time_last_angle_acquisition = state.time_current_angle_acquisition;
+    // state.time_last_angle_acquisition = state.time_current_angle_acquisition;
     Clock clock;
     state.time_current_angle_acquisition = clock.local_time();
 
@@ -87,10 +94,11 @@ void OmniEthernet::autoCalibration()
 
 void OmniEthernet::forceCallback(const omni_driver::OmniFeedback::ConstPtr &omnifeed)
 {
-    ////////////////////Some people might not like this extra damping, but it
-    ////////////////////helps to stabilize the overall force feedback. It isn't
-    ////////////////////like we are getting direct impedance matching from the
-    ////////////////////omni anyway
+    /**
+     * Some people might not like this extra damping, but it helps to stabilize 
+     * the overall force feedback. It isn't like we are getting direct impedance 
+     * matching from the omni anyway
+     **/
     this->state.control[0] = omnifeed->force.x - 0.001 * this->state.velocities[0];
     this->state.control[1] = omnifeed->force.y - 0.001 * this->state.velocities[1];
     this->state.control[2] = omnifeed->force.z - 0.001 * this->state.velocities[2];
@@ -103,11 +111,15 @@ void OmniEthernet::forceCallback(const omni_driver::OmniFeedback::ConstPtr &omni
 bool OmniEthernet::connect()
 {
 
-/*######################################################################################
-             The name must be the same configured in the geomagic software!
-  ######################################################################################*/
-    hHD = hdInitDevice("Phantom Omni");
-/*######################################################################################*/
+    /**
+     * This is the device name that is configured in the Touch_Setup. It currently 
+     * uses the default name.
+     * 
+     * TODO: This needs to used the name passed into the constructor to look for 
+     * the device. This will allow for multiple Geomagic Touch devices to be 
+     * connected to a single machine without clashes.
+     **/
+    hHD = hdInitDevice(HD_DEFAULT_DEVICE);
 
     if (HD_DEVICE_ERROR(error = hdGetError()))
     {


### PR DESCRIPTION
This is the initial commit for updates to be made to the driver. Some of
the changes include:
- The ethernet/usb driver now uses the default name assied by the setup
    tool instead of the custom driver name. This will be updated in
    future to fallback to the default if no custom name is provided.
- The libraries and build have been updated to for ROS Melodic.
- The README now includes references to all the repositories that I look
    to for reference during development. It also includes some disclaimers
    about the build.