### PR TITLE
Fix ROS Build and Configuration Issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ CMakeLists.txt.*
 .idea*
 .vscode
 .vscode*
+build/
+devel/
+logs/
+.catkin_tools/
+catkin/

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ setting up is needed to get the program up and running. If Docker is your way to
 to **The Docker way** session. Otherwise, you may choose to install the dependencies and compile the program
 from source. Once all dependencies are stored you may proceed to **Final steps**.
 
-The following command will install the required dependencies to compile the program from source:
+The following command will install the required dependencies to compile the program from source. Note that the C++ standard has been updated to C++14 to support modern compilers:
 ```sh
 $ sudo apt-get update
 $ sudo apt-get install build-essential libncurses5-dev freeglut3 dh-autoreconf \

--- a/omni_controller/CMakeLists.txt
+++ b/omni_controller/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(omni_controller)
 
+set(CMAKE_CXX_FLAGS "-std=c++14 ${CMAKE_CXX_FLAGS} -Wall")
+
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "RelWithDebInfo")
 endif ()
@@ -32,7 +34,7 @@ find_package(Eigen3 REQUIRED)
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-#  INCLUDE_DIRS include
+  INCLUDE_DIRS include
 #  LIBRARIES omni_controller
    CATKIN_DEPENDS std_msgs geometry_msgs joy
 #  DEPENDS system_lib
@@ -64,11 +66,11 @@ file(GLOB_RECURSE PROJECT_HEADERS "include/*.h")
 add_custom_target(omni_controller_files_for_ide SOURCES ${PROJECT_HEADERS})
 
 ## Create robot_kinematics library
-file(GLOB_RECURSE ROBOT_LIB_CPP ${PROJECT_SOURCE_DIR} src/RobotBase/*.cpp)
+file(GLOB_RECURSE ROBOT_LIB_CPP "src/RobotBase/*.cpp")
 add_library(robot_kinematics STATIC ${ROBOT_LIB_CPP})
 
 ## Declare a C++ ros node executable
-file(GLOB_RECURSE ROS_NODE_CPP ${PROJECT_SOURCE_DIR} src/node/*.cpp)
+file(GLOB_RECURSE ROS_NODE_CPP "src/node/*.cpp")
 add_executable(omni_controller ${ROS_NODE_CPP})
 
 ## Add cmake target dependencies of the executable

--- a/omni_driver/CMakeLists.txt
+++ b/omni_driver/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(omni_driver)
 
-set (CMAKE_CXX_FLAGS "--std=c++0x ${CMAKE_CXX_FLAGS} -Wall")
+set(CMAKE_CXX_FLAGS "-std=c++14 ${CMAKE_CXX_FLAGS} -Wall")
 
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "RelWithDebInfo")
@@ -26,6 +26,7 @@ find_package(catkin REQUIRED COMPONENTS
   moveit_ros_planning
   moveit_ros_move_group
   omni_controller
+  message_generation
 )
 
 find_package(Boost REQUIRED COMPONENTS thread)
@@ -79,7 +80,6 @@ catkin_package(
 #  LIBRARIES raw_omni
   CATKIN_DEPENDS
     geometry_msgs
-    omni_description
     roscpp
     std_msgs
     tf
@@ -87,6 +87,7 @@ catkin_package(
     moveit_ros_planning
     moveit_ros_move_group
     omni_controller
+    message_runtime
 #  DEPENDS system_lib
 )
 

--- a/omni_driver/package.xml
+++ b/omni_driver/package.xml
@@ -18,8 +18,10 @@
   <build_depend>moveit_ros_planning</build_depend>
   <build_depend>moveit_ros_move_group</build_depend>
   <build_depend>omni_controller</build_depend>
+  <build_depend>message_generation</build_depend>
 
   <run_depend>geometry_msgs</run_depend>
+  <run_depend>message_runtime</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>tf</run_depend>


### PR DESCRIPTION
This PR fixes several critical issues that prevented the ROS metapackage from building correctly:

1. **Message Generation**: Added `message_generation` and `message_runtime` dependencies to `omni_driver` to enable the generation of custom messages (`OmniButtonEvent.msg`, etc.).
2. **CMake Fixes**: 
   - Fixed incorrect globbing syntax in `omni_controller/CMakeLists.txt`.
   - Exported the `include` directory in `omni_controller` so it can be used by other packages.
   - Removed `omni_description` from `CATKIN_DEPENDS` in `omni_driver` as it is a runtime-only dependency.
3. **Modernization**: Updated the C++ standard from the outdated `c++0x` to `c++14` to ensure compatibility with modern compilers.
4. **Housekeeping**: Updated `.gitignore` to exclude build artifacts and updated `README.md` to reflect the C++ standard change.

---
*PR created automatically by Jules for task [17725222987578060575](https://jules.google.com/task/17725222987578060575) started by @jdrew1303*