### PR TITLE
Fix C++ Syntax and Eigen Mapping Errors in omni_driver

### DIFF
--- a/omni_driver/CMakeLists.txt
+++ b/omni_driver/CMakeLists.txt
@@ -115,7 +115,7 @@ add_custom_target(omni_driver_files_for_ide SOURCES
     "cfg/uncrustify.cfg")
 
 ## Declare a cpp library
-add_library(omni_driver_lib src/omnibase.cpp src/omnifirewire.cpp src/omniethernet.cpp src/omniusb.cpp src/raw1394msg.cpp src/math/omni_math.cpp)
+add_library(omni_driver_lib src/omnibase.cpp src/omnifirewire.cpp src/omniethernet.cpp src/omniusb.cpp src/raw1394msg.cpp src/math/omni_math.cpp src/math/moving_average.cpp)
 add_dependencies(omni_driver_lib omni_driver_generate_messages_cpp)
 
 ## Declare a cpp executable

--- a/omni_driver/CMakeLists.txt
+++ b/omni_driver/CMakeLists.txt
@@ -115,7 +115,7 @@ add_custom_target(omni_driver_files_for_ide SOURCES
     "cfg/uncrustify.cfg")
 
 ## Declare a cpp library
-add_library(omni_driver_lib src/omnibase.cpp src/omnifirewire.cpp src/omniethernet.cpp src/omniusb.cpp src/raw1394msg.cpp)
+add_library(omni_driver_lib src/omnibase.cpp src/omnifirewire.cpp src/omniethernet.cpp src/omniusb.cpp src/raw1394msg.cpp src/math/omni_math.cpp)
 add_dependencies(omni_driver_lib omni_driver_generate_messages_cpp)
 
 ## Declare a cpp executable

--- a/omni_driver/include/math/moving_average.hpp
+++ b/omni_driver/include/math/moving_average.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
 #include <vector>
+#include <stdexcept>
 
 class MovingAverage {
     private:
 
     int input_counter = 0;
     
-    std::vector<std::vector<double>> data(input_size);
+    std::vector<std::vector<double>> data;
     
     public: 
 
@@ -18,8 +19,8 @@ class MovingAverage {
 
     std::vector<double> mean() {
         std::vector<double> m(input_size);
-        for (unsigned int i =0; i < input_size; i++) {
-            for (unsigned int j =0; j < input_counter; j++) {
+        for (int i = 0; i < input_size; i++) {
+            for (int j = 0; j < input_counter; j++) {
                 m[i] += data[j][i];
             }
             if (input_counter > 0) m[i] = m[i]/input_counter; 
@@ -28,8 +29,9 @@ class MovingAverage {
     }
 
     void input(std::vector<double> input_data) {
-        if (input_data.size > input_size) throw std::logic_error("Input size must be fixed!.");
+        if (input_data.size() != (size_t)input_size) throw std::logic_error("Input size must be fixed!.");
         data.insert(data.begin(), input_data);
         data.resize(filter_size);
+        if (input_counter < filter_size) input_counter++;
     }
 };

--- a/omni_driver/include/math/omni_math.hpp
+++ b/omni_driver/include/math/omni_math.hpp
@@ -9,11 +9,12 @@
 #include <moveit/robot_model/robot_model.h>
 
 #include "../include/util/typedefs.hpp"
+#include "moving_average.hpp"
 
 class OmniMath {
     private:
 
-    MovingAverage moving_average(5,6);
+    MovingAverage moving_average;
 
     const bool enable_moving_average;
 
@@ -86,7 +87,7 @@ class OmniMath {
                     saturated_velocities[i] = previous_calculated_velocities[i];
                 }
             }
-            Eigen::VectorXd eigen_vector = Eigen::Map<Eigen::VectorXd>(saturated_velocities.data(), saturated_velocities.size());
+            Eigen::Map<Eigen::VectorXd> eigen_vector(saturated_velocities.data(), saturated_velocities.size());
             return eigen_vector;
         }
 
@@ -99,17 +100,17 @@ class OmniMath {
             double delta_t = (current_measurement_time - previous_measurement_time).total_microseconds();
             std::vector<double> calculated_velocities(6);
             for (int i = 0; i < 6; ++i) {
-                double deltaAngle = current_measurement[i] - previous_measurement[i];
-                calculated_velocities[i] = deltaAngle * 1000000 / delta_t;
+                double delta_angle = current_measurement[i] - previous_measurement[i];
+                calculated_velocities[i] = delta_angle * 1000000 / delta_t;
             }
             if (enable_moving_average) {
                 moving_average.input(calculated_velocities);
                 auto mean_vals = moving_average.mean();
-                Eigen::VectorXd joint_velocities = Eigen::Map<Eigen::VectorXd>(mean_vals.data(), mean_vals.size());
+                Eigen::Map<Eigen::VectorXd> joint_velocities(mean_vals.data(), mean_vals.size());
                 return joint_velocities;
             }
             else {
-                Eigen::VectorXd joint_velocities = Eigen::Map<Eigen::VectorXd>(calculated_velocities.data(), calculated_velocities.size());
+                Eigen::Map<Eigen::VectorXd> joint_velocities(calculated_velocities.data(), calculated_velocities.size());
                 return joint_velocities;
             }
         }

--- a/omni_driver/include/math/omni_math.hpp
+++ b/omni_driver/include/math/omni_math.hpp
@@ -8,7 +8,7 @@
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/robot_model/robot_model.h>
 
-#include "../include/util/typedefs.hpp"
+#include "../util/typedefs.hpp"
 #include "moving_average.hpp"
 
 class OmniMath {

--- a/omni_driver/include/math/omni_math.hpp
+++ b/omni_driver/include/math/omni_math.hpp
@@ -20,6 +20,8 @@ class OmniMath {
 
     public:
 
+    explicit OmniMath(const bool enable_moving_average);
+
     template <typename Type>
     Type saturate(Type value, Type min, Type max) {
         if (value < min) {
@@ -49,7 +51,6 @@ class OmniMath {
     Eigen::Vector3d calculateTorqueFeedback(
         robot_state::RobotStatePtr kinematic_state,
         robot_state::JointModelGroup* joint_model_group, 
-        //const Eigen::Vector3d& force,
         const Eigen::Vector3d force,
         Eigen::Matrix3d rot_link_to_teleop,
         double feedback_gain,
@@ -126,11 +127,4 @@ class OmniMath {
         kinematic_state->getJacobian(joint_model_group, end_effector_link_model, origin, jacobian, false);
         return jacobian * current_joint_velocities;
     }
-
-public:
-    /**
-     * @brief OmniBase constructor, sets some members and prepares ros topics and publishers.
-     * @param name Reference to string of omni name.
-     */
-    explicit OmniMath(const bool enable_moving_average);
 };

--- a/omni_driver/src/math/moving_average.cpp
+++ b/omni_driver/src/math/moving_average.cpp
@@ -1,0 +1,6 @@
+#include "math/moving_average.hpp"
+
+MovingAverage::MovingAverage(const int filter_size, const int input_size)
+    : filter_size(filter_size), input_size(input_size) {
+    data.resize(filter_size, std::vector<double>(input_size, 0.0));
+}

--- a/omni_driver/src/math/omni_math.cpp
+++ b/omni_driver/src/math/omni_math.cpp
@@ -1,10 +1,5 @@
 #include "math/omni_math.hpp"
 
-MovingAverage::MovingAverage(const int filter_size, const int input_size)
-    : filter_size(filter_size), input_size(input_size) {
-    data.resize(filter_size, std::vector<double>(input_size, 0.0));
-}
-
 OmniMath::OmniMath(const bool enable_moving_average)
     : moving_average(5, 6), enable_moving_average(enable_moving_average) {
 }

--- a/omni_driver/src/math/omni_math.cpp
+++ b/omni_driver/src/math/omni_math.cpp
@@ -1,0 +1,10 @@
+#include "math/omni_math.hpp"
+
+MovingAverage::MovingAverage(const int filter_size, const int input_size)
+    : filter_size(filter_size), input_size(input_size) {
+    data.resize(filter_size, std::vector<double>(input_size, 0.0));
+}
+
+OmniMath::OmniMath(const bool enable_moving_average)
+    : moving_average(5, 6), enable_moving_average(enable_moving_average) {
+}

--- a/omni_driver/src/omnibase.cpp
+++ b/omni_driver/src/omnibase.cpp
@@ -349,7 +349,7 @@ void OmniBase::forceFeedbackCallback(const std_msgs::Float64MultiArray::ConstPtr
 {
     // Optoforce is not precise enough on all axis.
     Eigen::Vector3d force_vector(0, force->data[0], 0);
-    Eigen::Vector3d joint_torques = OmniBase::calculateTorqueFeedback(force_vector, force_feedback_gain);
+    Eigen::Vector3d joint_torques = calculateTorqueFeedback(force_vector, force_feedback_gain);
     std::vector<double> torque_input(3);
     std::copy(joint_torques.data(), joint_torques.data() + 3, torque_input.begin());
     this->setTorque(torque_input);

--- a/omni_driver/src/omnibase.cpp
+++ b/omni_driver/src/omnibase.cpp
@@ -101,7 +101,7 @@ OmniBase::OmniBase(const std::string &name, const std::string &path_urdf, const 
     if (rot_data.empty())
         rot_link_to_teleop.setIdentity();
     else if (rot_data.size() == 9)
-        rot_link_to_teleop = Eigen::Matrix3d(rot_data.data());
+        rot_link_to_teleop = Eigen::Map<Eigen::Matrix3d>(rot_data.data());
     else
         throw std::logic_error("Rotation matrix is represented by a 9 element array");
 

--- a/omni_driver/src/test_omnibase.cpp
+++ b/omni_driver/src/test_omnibase.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include "omnibase.h"
+#include "math/omni_math.hpp"
 #include <ros/ros.h>
 #include <Eigen/Geometry>
 
@@ -84,6 +85,24 @@ TEST_F(OmniBaseTest, TorqueFeedbackRotation) {
 
     // For this test, I'll just check it's non-zero and later I could add more specific values if I had a reference.
     EXPECT_GT(torques.norm(), 0);
+}
+
+TEST(OmniMathTest, JerkSaturationFilter) {
+    OmniMath omni_math(false);
+    Eigen::VectorXd prev_vel(6);
+    prev_vel << 1.0, 1.0, 1.0, 1.0, 1.0, 1.0;
+    Eigen::VectorXd curr_vel(6);
+    curr_vel << 1.1, 2.5, 0.9, 1.0, 3.0, 1.0;
+    double max_jerk = 0.5;
+
+    Eigen::VectorXd saturated = omni_math.jerkSaturationFilter(prev_vel, curr_vel, max_jerk);
+
+    EXPECT_DOUBLE_EQ(saturated[0], 1.1); // 1.1 - 1.0 = 0.1 < 0.5
+    EXPECT_DOUBLE_EQ(saturated[1], 1.0); // 2.5 - 1.0 = 1.5 > 0.5 -> prev
+    EXPECT_DOUBLE_EQ(saturated[2], 0.9); // 0.9 - 1.0 = -0.1 -> abs(0.1) < 0.5
+    EXPECT_DOUBLE_EQ(saturated[3], 1.0); // 1.0 - 1.0 = 0 < 0.5
+    EXPECT_DOUBLE_EQ(saturated[4], 1.0); // 3.0 - 1.0 = 2.0 > 0.5 -> prev
+    EXPECT_DOUBLE_EQ(saturated[5], 1.0); // 1.0 - 1.0 = 0 < 0.5
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This PR addresses critical compilation and syntax issues in the omni_driver package.
Key changes include:
1. Fixing scoping and syntax errors in `omni_math.hpp` and `moving_average.hpp`.
2. Refactoring `MovingAverage` and `OmniMath` constructors to handle initialization correctly and avoid 'most vexing parse'.
3. Correcting Eigen library usage by replacing raw pointer-based matrix/vector initialization with `Eigen::Map`.
4. Adding a GTest for `jerkSaturationFilter` to verify the logic and memory mapping.
5. Updating build infrastructure (`CMakeLists.txt`) to include the new math implementation file.

Fixes #14

---
*PR created automatically by Jules for task [12055110451549830796](https://jules.google.com/task/12055110451549830796) started by @jdrew1303*